### PR TITLE
Added an argument to disable SSL certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This will display detailed usage information.
 - `--log_level`: Log level (default: `INFO`).
 - `--print_report`: Print a detailed report of all processed files at the end.
 - `--include_metadata`: Include metadata on tokens consumed and the context passed to LLMs for prompt studio exported tools in the result for each file.
+- `--no-verify`: Disable SSL certificate verification. (By default, SSL verification is enabled.)
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will display detailed usage information.
 - `--log_level`: Log level (default: `INFO`).
 - `--print_report`: Print a detailed report of all processed files at the end.
 - `--include_metadata`: Include metadata on tokens consumed and the context passed to LLMs for prompt studio exported tools in the result for each file.
-- `--no-verify`: Disable SSL certificate verification. (By default, SSL verification is enabled.)
+- `--no_verify`: Disable SSL certificate verification. (By default, SSL verification is enabled.)
 
 ## Usage Examples
 

--- a/main.py
+++ b/main.py
@@ -421,7 +421,7 @@ def main():
     )
 
     parser.add_argument(
-        "--no-verify",
+        "--no_verify",
         dest="verify",
         action="store_false",
         help="Disable SSL certificate verification.",

--- a/main.py
+++ b/main.py
@@ -451,5 +451,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ class Arguments:
     log_level: str = "INFO"
     print_report: bool = False
     include_metadata: bool = False
+    verify: bool = True
 
 
 # Initialize SQLite DB
@@ -246,6 +247,7 @@ def process_file(
             api_timeout=args.api_timeout,
             logging_level=args.log_level,
             include_metadata=args.include_metadata,
+            verify=args.verify,
         )
 
         status_endpoint, execution_status, response = get_status_endpoint(
@@ -418,6 +420,14 @@ def main():
         help="Include metadata on tokens consumed and the context passed to LLMs for prompt studio exported tools in the result for each file.",
     )
 
+    parser.add_argument(
+        "--no-verify",
+        dest="verify",
+        action="store_false",
+        help="Disable SSL certificate verification.",
+    )
+
+
     args = Arguments(**vars(parser.parse_args()))
 
     ch = logging.StreamHandler(sys.stdout)
@@ -441,3 +451,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+


### PR DESCRIPTION
- Added `--no-verify` argument to disable SSL certificate verification
- SSL verification is enabled by default unless --no-verify is specified
- Updated documentation to reflect the default behavior